### PR TITLE
[TC1] Recommendation - Favorites cache that goes into recommendation algorithm (similar types == higher rank) 

### DIFF
--- a/frontend/src/components/MainPage.jsx
+++ b/frontend/src/components/MainPage.jsx
@@ -83,6 +83,10 @@ export default function MainPage() {
     localStorage.setItem('artBase_userInteractions', JSON.stringify(updatedInteractions));
   };
 
+
+
+
+
   // get user's most searched terms
   const getUserMostSearched = () => {
     const queryCounts = {};

--- a/frontend/src/components/PlacePage.jsx
+++ b/frontend/src/components/PlacePage.jsx
@@ -17,6 +17,23 @@ function PlacePage() {
   const [error, setError] = useState(null);
   const [isFavorite, setIsFavorite] = useState(false);
 
+  // to add a favorite to localstorage
+  const addFavorite = (placeId) => {
+    const favorites = JSON.parse(localStorage.getItem('artBase_favorites') || '[]');
+    if (!favorites.includes(placeId)) {
+      favorites.push(placeId);
+      localStorage.setItem('artBase_favorites', JSON.stringify(favorites));
+    }
+  };
+  
+  // to remove a favorite from local storage
+  const removeFavorite = (placeId) => {
+    const favorites = JSON.parse(localStorage.getItem('artBase_favorites') || '[]');
+    const updated = favorites.filter(id => id !== placeId);
+    localStorage.setItem('artBase_favorites', JSON.stringify(updated));
+  }; 
+  
+
   useEffect(() => {
     if (!window.google || !window.google.maps) {
       const script = document.createElement('script');
@@ -62,6 +79,7 @@ function PlacePage() {
       if (response.ok) {
         setIsFavorite(true);
       }
+      addFavorite(placeId)
     } catch (err) {
       console.error('Fetch failed:', err);
     }
@@ -79,6 +97,7 @@ function PlacePage() {
     } catch (err) {
       console.error('Fetch failed:', err);
     }
+    removeFavorite(placeId)
   };
 
   if (error) {


### PR DESCRIPTION
## Description

This PR implements a localStorage-based favorites system and integrates it into the recommendation algorithm. Users can now favorite/unfavorite places, and the recommendation engine will prioritize place types (art galleries or museums) that the user has favorited or viewed most. Favorited types are weighted more heavily than viewed types, resulting in more personalized recommendations.

- Added addFavorite and removeFavorite functions to manage favorites in localStorage (artBase_favorites).
- Updated UI to call these functions when favoriting/unfavoriting a place.
- Recommendation algorithm in RecommendedPage.jsx now uses both favorited and viewed places to determine user preferences, with favorited types counting double.
- Type score is normalized and used as a core part of the ranking formula.

## Milestones

[x] Implement localStorage-based favorites system.
[x] Wire up favorite/unfavorite UI to localStorage.
[x] Refactor recommendation algorithm to use both favorites and views, with correct weighting.
[x] Add code comments and documentation.

## Resources
https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage

## Test Plan
 - Favorite and unfavorite several places in the UI.
- Check that artBase_favorites in localStorage updates accordingly.
- Refresh the page and verify that favorites and recommendations persist.
- Debug log for score breakdown that verifies that it works. 
            console.log({
                name: place.name,
                placeId: place.place_id,
                distanceScore,
                priceScore,
                ratingScore,
                typeScore,
                rankScore
            });
