### PR TITLE
Fetching from API is expanded to fetch with keywords 'exhibition' and 'art fair' for more expansive results

### DIFF
--- a/frontend/src/components/MainPage.jsx
+++ b/frontend/src/components/MainPage.jsx
@@ -83,6 +83,10 @@ export default function MainPage() {
     localStorage.setItem('artBase_userInteractions', JSON.stringify(updatedInteractions));
   };
 
+
+
+
+
   // get user's most searched terms
   const getUserMostSearched = () => {
     const queryCounts = {};

--- a/frontend/src/components/PlacePage.jsx
+++ b/frontend/src/components/PlacePage.jsx
@@ -17,6 +17,23 @@ function PlacePage() {
   const [error, setError] = useState(null);
   const [isFavorite, setIsFavorite] = useState(false);
 
+  // to add a favorite to localstorage
+  const addFavorite = (placeId) => {
+    const favorites = JSON.parse(localStorage.getItem('artBase_favorites') || '[]');
+    if (!favorites.includes(placeId)) {
+      favorites.push(placeId);
+      localStorage.setItem('artBase_favorites', JSON.stringify(favorites));
+    }
+  };
+  
+  // to remove a favorite from local storage
+  const removeFavorite = (placeId) => {
+    const favorites = JSON.parse(localStorage.getItem('artBase_favorites') || '[]');
+    const updated = favorites.filter(id => id !== placeId);
+    localStorage.setItem('artBase_favorites', JSON.stringify(updated));
+  }; 
+  
+
   useEffect(() => {
     if (!window.google || !window.google.maps) {
       const script = document.createElement('script');
@@ -62,6 +79,7 @@ function PlacePage() {
       if (response.ok) {
         setIsFavorite(true);
       }
+      addFavorite(placeId)
     } catch (err) {
       console.error('Fetch failed:', err);
     }
@@ -79,6 +97,7 @@ function PlacePage() {
     } catch (err) {
       console.error('Fetch failed:', err);
     }
+    removeFavorite(placeId)
   };
 
   if (error) {

--- a/frontend/src/components/RecommendedPage.jsx
+++ b/frontend/src/components/RecommendedPage.jsx
@@ -67,10 +67,15 @@ export default function RecommendedPage() {
                     radius: 50000,
                     type: 'museum',
                 };
-                const requestKeyword = {
+                const requestArtFair = {
                     location: userLocation,
                     radius: 50000,
                     keyword: 'art fair',
+                };
+                const requestExhibition = {
+                    location: userLocation,
+                    radius: 50000,
+                    keyword: 'exhibition',
                 };
                 // fetch art galleries
                 service.nearbySearch(requestGallery, (resultsGallery, statusGallery) => {
@@ -83,19 +88,27 @@ export default function RecommendedPage() {
                         if (statusMuseum === window.google.maps.places.PlacesServiceStatus.OK && resultsMuseum.length > 0) {
                             allResults = [...allResults, ...resultsMuseum];
                         }
-                        // fetch by keyword and merge
-                        service.nearbySearch(requestKeyword, (resultsKeyword, statusKeyword) => {
-                            if (statusKeyword === window.google.maps.places.PlacesServiceStatus.OK && resultsKeyword.length > 0) {
-                                //merge all results, removing duplicates by place_id
-                                const merged = [...allResults, ...resultsKeyword].reduce((acc, place) => {
-                                    if (!acc.some(p => p.place_id === place.place_id)) {
-                                        acc.push(place);
-                                    }
-                                    return acc;
-                                }, []);
-                                setPlaces(merged);
-                            } else {
-                                //merge galleries and museums only
+                        // fetch art fairs
+                        service.nearbySearch(requestArtFair, (resultsArtFair, statusArtFair) => {
+                            if (statusArtFair === window.google.maps.places.PlacesServiceStatus.OK && resultsArtFair.length > 0) {
+                                // tag art fair results
+                                resultsArtFair.forEach(place => {
+                                    if (!place.types) place.types = [];
+                                    if (!place.types.includes('art_fair')) place.types.push('art_fair');
+                                });
+                                allResults = [...allResults, ...resultsArtFair];
+                            }
+                            // fetch exhibitions
+                            service.nearbySearch(requestExhibition, (resultsExhibition, statusExhibition) => {
+                                if (statusExhibition === window.google.maps.places.PlacesServiceStatus.OK && resultsExhibition.length > 0) {
+                                    // tag exhibition results
+                                    resultsExhibition.forEach(place => {
+                                        if (!place.types) place.types = [];
+                                        if (!place.types.includes('exhibition')) place.types.push('exhibition');
+                                    });
+                                    allResults = [...allResults, ...resultsExhibition];
+                                }
+                                // merge all results, removing duplicates by place_id
                                 const merged = allResults.reduce((acc, place) => {
                                     if (!acc.some(p => p.place_id === place.place_id)) {
                                         acc.push(place);
@@ -103,11 +116,10 @@ export default function RecommendedPage() {
                                     return acc;
                                 }, []);
                                 setPlaces(merged);
-                            }
-                            setTimeout(() => {
-                                setLoading(false);
-                            }, 3000); //add 3 second delay before hiding loading
-
+                                setTimeout(() => {
+                                    setLoading(false);
+                                }, 3000);
+                            });
                         });
                     });
                 });
@@ -144,7 +156,7 @@ export default function RecommendedPage() {
             const place = places.find(p => p.place_id === id);
             if (place && place.types) {
                 place.types.forEach(type => {
-                    if (type === 'art_gallery' || type === 'museum') {
+                    if (type === 'art_gallery' || type === 'museum' || type === 'art_fair' || type === 'exhibition') {
                         typeCounts[type] = (typeCounts[type] || 0) + 2;
                     }
                 });
@@ -156,7 +168,7 @@ export default function RecommendedPage() {
             const place = places.find(p => p.place_id === id);
             if (place && place.types) {
                 place.types.forEach(type => {
-                    if (type === 'art_gallery' || type === 'museum') {
+                    if (type === 'art_gallery' || type === 'museum' || type === 'art_fair' || type === 'exhibition') {
                         typeCounts[type] = (typeCounts[type] || 0) + 1;
                     }
                 });


### PR DESCRIPTION
## Description

This PR introduces keyword-based fetching and filtering to the Main Page using the Google Maps Places API. Users can now filter results not only by place type (art gallery, museum) but also by keywords such as "Art Fair" and "Exhibition." The UI now includes dedicated filter buttons for these keywords, and the logic merges results from type and keyword searches, removing duplicates.

- Added filter buttons for "Art Fairs" and "Exhibitions" on the Main Page.
- When a keyword filter is selected, the app fetches places using the corresponding keyword via the Google Maps Places API.
- When a type filter is selected, the app fetches by type and also merges in results for "Art Fair" and "Exhibition" keywords.
- Results are deduplicated by place_id before display.
- Enhanced user experience by allowing discovery of more event-based and exhibition-based places.

## Milestones
[x] Add state and logic for keyword-based search in MainPage.
[x] Add filter buttons for "Art Fairs" and "Exhibitions."
[x] Update fetching logic to support both type and keyword-based searches.
[x] Merge and unduplicate results from multiple queries.
[x] Update UI to reflect the new filters and results.

## Resources
https://developers.google.com/maps/documentation/javascript/places#place_search_requests

## Test Plan
![Untitled design (2)](https://github.com/user-attachments/assets/8eddca16-78f1-4cb0-af37-959dea4794a5)

