### PR TITLE
re-arranging recommendation algorithm and fixing type score that was …

### DIFF
--- a/frontend/src/components/MainPage.jsx
+++ b/frontend/src/components/MainPage.jsx
@@ -76,14 +76,16 @@ export default function MainPage() {
   };
 
   // track user interaction with a place
-  const trackUserInteraction = (placeId, interactionType) => {
+  const trackUserInteraction = (place, interactionType) => {
     const timestamp = new Date().toISOString();
     const updatedInteractions = {
       ...userInteractions,
-      [placeId]: {
-        ...userInteractions[placeId],
+      [place.place_id]: {
+        ...userInteractions[place.place_id],
         [interactionType]: timestamp,
         lastInteraction: timestamp,
+        types: place.types,
+        name: place.name
       }
     };
     
@@ -287,6 +289,7 @@ export default function MainPage() {
       vicinity: place.vicinity,
       location: place.location,
       photoUrl,
+      types: place.types
     };
     return (
       <Card
@@ -297,7 +300,7 @@ export default function MainPage() {
         placeId={place.place_id}
         place={placeObject}
         // track when a user clicks/views a card
-        onCardClick={() => trackUserInteraction(place.place_id, 'viewed')}
+        onCardClick={() => trackUserInteraction(place, 'viewed')}
       />
     );
   }

--- a/frontend/src/components/PlacePage.jsx
+++ b/frontend/src/components/PlacePage.jsx
@@ -18,18 +18,27 @@ function PlacePage() {
   const [isFavorite, setIsFavorite] = useState(false);
 
   // to add a favorite to localstorage
-  const addFavorite = (placeId) => {
-    const favorites = JSON.parse(localStorage.getItem('artBase_favorites') || '[]');
-    if (!favorites.includes(placeId)) {
-      favorites.push(placeId);
+  const addFavorite = (placeId, types) => {
+    let favorites = JSON.parse(localStorage.getItem('artBase_favorites') || '[]');
+    // check if already favorited (by id)
+    const already = favorites.some(fav => (typeof fav === 'object' && fav.id === placeId) || fav === placeId);
+    if (!already) {
+      favorites.push({ id: placeId, types: types });
       localStorage.setItem('artBase_favorites', JSON.stringify(favorites));
     }
   };
   
   // to remove a favorite from local storage
   const removeFavorite = (placeId) => {
-    const favorites = JSON.parse(localStorage.getItem('artBase_favorites') || '[]');
-    const updated = favorites.filter(id => id !== placeId);
+    let favorites = JSON.parse(localStorage.getItem('artBase_favorites') || '[]');
+    //remove by id property if object, or by value if string
+    const updated = favorites.filter(fav => {
+      if (typeof fav === 'object' && fav !== null && fav.id) {
+        return fav.id !== placeId;
+      } else {
+        return fav !== placeId;
+      }
+    });
     localStorage.setItem('artBase_favorites', JSON.stringify(updated));
   }; 
   
@@ -79,7 +88,13 @@ function PlacePage() {
       if (response.ok) {
         setIsFavorite(true);
       }
-      addFavorite(placeId)
+      //use details.place_id and details.types for storing
+      if (details && details.place_id && details.types) {
+        addFavorite(details.place_id, details.types);
+      } else {
+        // fallback: just store the id
+        addFavorite(placeId, []);
+      }
     } catch (err) {
       console.error('Fetch failed:', err);
     }


### PR DESCRIPTION
…coming out to zero

## Description
This PR updates the recommendation algorithm and favorites logic to ensure that user favorites always contribute to type-based recommendations, even if the favorited places are not present in the current search results (e.g., when searching in a different city).

Favorites Storage:
- Favorites are now stored as objects with both id and types (and can be migrated from old string-only format).
- When a user favorites a place, its types are saved in localStorage.

Recommendation Algorithm:
- The algorithm now uses the types from all favorites, not just those in the current search results.
- Un-favoriting works for both the new object format and the old string format.


## Milestones
[x] Store types with favorites in localStorage
[x] Update recommendation algorithm to use types from all favorites
[x] Removal of favorites

## Resources
https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage


## Test Plan

-Favorite a place and check localStorage (artBase_favorites) to confirm it stores both id and types.
- Favorite a place in one city, then search in another city. Confirm that similar types are recommended higher.
- Unfavorite a place and confirm it is removed from localStorage


- I used console logs to find what was showing in the localStorage and why it wasn't saving the typings. 

console.log('[RECOMMENDATION DEBUG] Raw localStorage favorites:', localStorage.getItem('artBase_favorites'));
 console.log('[RECOMMENDATION DEBUG] Raw localStorage interactions:', localStorage.getItem('artBase_userInteractions'));
console.log(`[RECOMMENDATION DEBUG] Found ${foundFavorites} favorites, ${notFoundFavorites} not found`);

