### PR TITLE
added typo keyboard adjacency to search algorithm

### DIFF
--- a/frontend/src/utils/searchAlgorithm.js
+++ b/frontend/src/utils/searchAlgorithm.js
@@ -2,8 +2,56 @@
 export const SYNONYM_GROUPS = [
   ['gallery', 'galleries', 'art exhibit', 'art space', 'art center'],
   ['museum', 'museums', 'art museum', 'art museums', 'cultural institution', 'cultural institutions'],
-  ['modern', 'contemporary', 'abstract']
+  ['modern', 'contemporary', 'abstract'],
+  ['exhibition', 'show', 'display', 'installation'],
+  ['fair', 'art fair', 'bazaar', 'market'],
+  ['sculpture', 'statue', 'installation'],
+  ['painting', 'canvas', 'oil painting', 'acrylic', 'watercolor'],
+  ['photography', 'photo', 'photograph', 'print'],
+  ['historic', 'heritage', 'classic', 'traditional'],
+  ['public art', 'outdoor art', 'mural', 'street art'],
+  ['performance', 'live art', 'theater', 'dance', 'music']
 ];
+
+// QWERTY keyboard adjacency map
+const KEYBOARD_ADJACENCY = {
+  a: ['q', 'w', 's', 'z'],
+  b: ['v', 'g', 'h', 'n'],
+  c: ['x', 'd', 'f', 'v'],
+  d: ['s', 'e', 'r', 'f', 'c', 'x'],
+  e: ['w', 's', 'd', 'r'],
+  f: ['d', 'r', 't', 'g', 'v', 'c'],
+  g: ['f', 't', 'y', 'h', 'b', 'v'],
+  h: ['g', 'y', 'u', 'j', 'n', 'b'],
+  i: ['u', 'j', 'k', 'o'],
+  j: ['h', 'u', 'i', 'k', 'n', 'm'],
+  k: ['j', 'i', 'o', 'l', 'm'],
+  l: ['k', 'o', 'p'],
+  m: ['n', 'j', 'k'],
+  n: ['b', 'h', 'j', 'm'],
+  o: ['i', 'k', 'l', 'p'],
+  p: ['o', 'l'],
+  q: ['a', 'w'],
+  r: ['e', 'd', 'f', 't'],
+  s: ['a', 'w', 'e', 'd', 'x', 'z'],
+  t: ['r', 'f', 'g', 'y'],
+  u: ['y', 'h', 'j', 'i'],
+  v: ['c', 'f', 'g', 'b'],
+  w: ['q', 'a', 's', 'e'],
+  x: ['z', 's', 'd', 'c'],
+  y: ['t', 'g', 'h', 'u'],
+  z: ['a', 's', 'x'],
+};
+
+function keyboardProximityCost(aChar, bChar) {
+  if (aChar === bChar){
+    return 0;
+  } 
+  if (KEYBOARD_ADJACENCY[aChar] && KEYBOARD_ADJACENCY[aChar].includes(bChar)) {
+    return 0.5;
+  } 
+  return 1;
+}
 
 // compute difference between two strings
 // returns min number of single-character required to change a to b
@@ -27,13 +75,31 @@ export function fuzzyAlgo(a, b) {
   }
   for (let i = 1; i <= b.length; i++) {
     for (let j = 1; j <= a.length; j++) {
+      let cost;
+      if (b.charAt(i - 1) === a.charAt(j - 1)) {
+        cost = 0;
+      } else {
+        cost = keyboardProximityCost(b.charAt(i - 1), a.charAt(j - 1));
+      }
       if (b.charAt(i - 1) === a.charAt(j - 1)) {
         matrix[i][j] = matrix[i - 1][j - 1];
       } else {
         matrix[i][j] = Math.min(
-          matrix[i - 1][j - 1] + 1, // substitution
+          matrix[i - 1][j - 1] + cost, // substitution (with keyboard proximity)
           matrix[i][j - 1] + 1,     // insertion
           matrix[i - 1][j] + 1      // deletion
+        );
+      }
+      //check for transposition (damerau-levenshtein)
+      if (
+        i > 1 &&
+        j > 1 &&
+        b.charAt(i - 1) === a.charAt(j - 2) &&
+        b.charAt(i - 2) === a.charAt(j - 1)
+      ) {
+        matrix[i][j] = Math.min(
+          matrix[i][j],
+          matrix[i - 2][j - 2] + 1 // transposition
         );
       }
     }


### PR DESCRIPTION
## Description

This PR enhances the search algorithm's typo tolerance by implementing keyboard adjacency. The fuzzy matching algorithm now considers the physical layout of QWERTY keyboards when calculating edit distances, penalizing to a lesser degree common keyboard typos. Reduced penalty (0.5) for substitutions involving adjacent keys vs. full penalty (1.0) for distant keys. For example nusiem == musuem because the two typos are near each other on the keyboard.

## Milestones

[X] More forgiving of close key typo errors in the fuzzy algorithm. 
[X] Transposition added to fuzzy algorithm that allows keys to be swapped. 

## Resources
- Damerau-Levenshtein Distance: Base algorithm for fuzzy string matching. Damerau part means I added transposition, so keys can be swapped and even though it's two misplaced letters, it is forgiving of transposition. 
- Metamate to help with the keyboard adjacency

## Test Plan
Since two similar keys count for .5 penalty, the max is 1 so it allows for two different key typos because they are close to each other on the QWERTY keyboard. 

![Untitled design (3)](https://github.com/user-attachments/assets/84e49269-9e24-4a4e-80a5-a31420eaa633)
